### PR TITLE
Fix configuration test running every Chef run regardless of service action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - resolved cookstyle error: test/cookbooks/syslog_ng_test/recipes/package_copr.rb:22:14 refactor: `ChefCorrectness/InvalidPlatformFamilyInCase`
+- Fix configuration test running every Chef run regardless of service action - [@bmhughes](https://github.com/bmhughes)
 
 ## 1.0.0 (2020-05-14)
 


### PR DESCRIPTION
Description

- Fix configuration test running every Chef run regardless of service action

## Issues Resolved

- None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
