### PR TITLE
Re-enable CentOS 8 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       matrix:
         os:
           - 'centos-7'
+          - 'centos-8'
           - 'fedora-31'
           - 'debian-10'
           - 'ubuntu-1804'


### PR DESCRIPTION
# Description

The upstream dokken issue has been resolved so we can re-enable CI testing on CentOS 8

## Issues Resolved

#34 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
