### PR TITLE
Remove service action from ruby_block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove service action from ruby_block - [@bmhughes](https://github.com/bmhughes)
+
 ## 1.1.0 - *2020-11-27*
 
 - Add enable/disable actions to control a configuration item whilst leaving the configuration file in place - [@bmhughes](https://github.com/bmhughes)

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -39,34 +39,25 @@ action_class do
   def do_service_action(resource_action)
     with_run_context(:root) do
       if %i(start restart reload).include?(resource_action)
-        edit_resource(:ruby_block, "Run pre #{new_resource.service_name} #{resource_action} configuration test") do
-          block do
-            begin
-              if new_resource.config_test
-                cmd = Mixlib::ShellOut.new("#{syslog_ng_binary} -s")
-                cmd.run_command.error!
-                Chef::Log.info("Configuration test passed, creating #{new_resource.service_name} #{new_resource.declared_type} resource with action #{resource_action}")
-              else
-                Chef::Log.info("Configuration test disabled, creating #{new_resource.service_name} #{new_resource.declared_type} resource with action #{resource_action}")
-              end
-
-              edit_resource(:service, new_resource.service_name) do
-                action :nothing
-                delayed_action resource_action
-              end
-            rescue Mixlib::ShellOut::ShellCommandFailed
-              if new_resource.config_test_fail_action.eql?(:log)
-                Chef::Log.error("Configuration test failed, #{new_resource.service_name} #{resource_action} action aborted!\n\nError\n-----\n#{cmd.stderr}")
-              else
-                raise "Configuration test failed, #{new_resource.service_name} #{resource_action} action aborted!\n\nError\n-----\n#{cmd.stderr}"
-              end
-            end
+        begin
+          if new_resource.config_test
+            cmd = Mixlib::ShellOut.new("#{syslog_ng_binary} -s")
+            cmd.run_command.error!
+            Chef::Log.info("Configuration test passed, creating #{new_resource.service_name} #{new_resource.declared_type} resource with action #{resource_action}")
+          else
+            Chef::Log.info("Configuration test disabled, creating #{new_resource.service_name} #{new_resource.declared_type} resource with action #{resource_action}")
           end
 
-          only_if { ::File.exist?(new_resource.config_file) }
-
-          action :nothing
-          delayed_action :run
+          edit_resource(:service, new_resource.service_name) do
+            action :nothing
+            delayed_action resource_action
+          end
+        rescue Mixlib::ShellOut::ShellCommandFailed
+          if new_resource.config_test_fail_action.eql?(:log)
+            Chef::Log.error("Configuration test failed, #{new_resource.service_name} #{resource_action} action aborted!\n\nError\n-----\n#{cmd.stderr}")
+          else
+            raise "Configuration test failed, #{new_resource.service_name} #{resource_action} action aborted!\n\nError\n-----\n#{cmd.stderr}"
+          end
         end
       else
         edit_resource(:service, new_resource.service_name.delete_suffix('.service')) do

--- a/test/cookbooks/syslog_ng_test/recipes/config.rb
+++ b/test/cookbooks/syslog_ng_test/recipes/config.rb
@@ -23,5 +23,6 @@ syslog_ng_config '/etc/syslog-ng/syslog-ng.conf' do
 end
 
 syslog_ng_service 'syslog-ng' do
-  action [:enable, :start]
+  action :enable
+  delayed_action :start
 end


### PR DESCRIPTION
# Description

Remove service action from ruby_block for idempotence purposes.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
