### PR TITLE
fix(library): chef 19/ruby 3.4 called backtrace format change

### DIFF
--- a/documentation/syslog_ng_block.md
+++ b/documentation/syslog_ng_block.md
@@ -11,18 +11,18 @@
 
 ## Properties
 
-| Name                   | Type          | Default                          | Description                                                         | Allowed Values      |
-| ---------------------- | ------------- | -------------------------------- | ------------------------------------------------------------------- | ------------------- |
-| `config_dir`           | String        | `/etc/syslog-ng/destionation.d`  | Directory to create configuration file in                           |                     |
-| `cookbook`             | String        | `syslog-ng`                      | Cookbook to source configuration file template from                 |                     |
-| `template`             | String        | `syslog-ng/destination.conf.erb` | Template to use to generate the configuration file                  |                     |
-| `owner`                | String        | `root`                           | Owner of the generated configuration file                           |                     |
-| `group`                | String        | `root`                           | Group of the generated configuration file                           |                     |
-| `mode`                 | String        | `0640`                           | Filemode of the generated configuration file                        |                     |
-| `description`          | String        |                                  | Unparsed description to add to the configuration file               |                     |
-| `type`                 | Symbol        |                                  | Block type                                                          | `:destination`, `:filter`, `:log`, `:options`, `:parser`, `:rewrite`, `:root`, `:source` |
-| `parameters`           | Hash          |                                  | Block parameters and default values, use `:empty` to have no default|                     |
-| `definition`           | Hash          |                                  | Hash or Array of Hash containing raw driver(s) configuration        |                     |
+| Name          | Type   | Default                          | Description                                                          | Allowed Values                                                                           |
+| ------------- | ------ | -------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `config_dir`  | String | `/etc/syslog-ng/destionation.d`  | Directory to create configuration file in                            |                                                                                          |
+| `cookbook`    | String | `syslog-ng`                      | Cookbook to source configuration file template from                  |                                                                                          |
+| `template`    | String | `syslog-ng/destination.conf.erb` | Template to use to generate the configuration file                   |                                                                                          |
+| `owner`       | String | `root`                           | Owner of the generated configuration file                            |                                                                                          |
+| `group`       | String | `root`                           | Group of the generated configuration file                            |                                                                                          |
+| `mode`        | String | `0640`                           | Filemode of the generated configuration file                         |                                                                                          |
+| `description` | String |                                  | Unparsed description to add to the configuration file                |                                                                                          |
+| `type`        | Symbol |                                  | Block type                                                           | `:destination`, `:filter`, `:log`, `:options`, `:parser`, `:rewrite`, `:root`, `:source` |
+| `parameters`  | Hash   |                                  | Block parameters and default values, use `:empty` to have no default |                                                                                          |
+| `definition`  | Hash   |                                  | Hash or Array of Hash containing raw driver(s) configuration         |                                                                                          |
 
 ## Usage
 

--- a/documentation/syslog_ng_config.md
+++ b/documentation/syslog_ng_config.md
@@ -11,22 +11,22 @@ Generates the `syslog-ng.conf` file containing the global configuration.
 
 ## Properties
 
-| Name                   | Type          | Default                          | Description                                                         | Allowed Values      |
-| ---------------------- | ------------- | -------------------------------- | ------------------------------------------------------------------- | ------------------- |
-| `config_file`          | String        | `/etc/syslog-ng/syslog-ng.conf`  | The path to the Syslog-NG server configuration on disk              |                     |
-| `config_version`       | String, Float | Installed version                | The configuration file software version                             |                     |
-| `cookbook`             | String        | `syslog-ng`                      | Cookbook to source configuration file template from                 |                     |
-| `template`             | String        | `syslog-ng/syslog-ng.conf.erb`   | Template to use to generate the configuration file                  |                     |
-| `owner`                | String        | `root`                           | Owner of the generated configuration file                           |                     |
-| `group`                | String        | `root`                           | Group of the generated configuration file                           |                     |
-| `mode`                 | String        | `0640`                           | Filemode of the generated configuration file                        |                     |
-| `options`              | Hash          | Default global syslog options    | Syslog-NG server global options                                     |                     |
-| `source`               | Hash          | Default global syslog sources    | Syslog-NG server global log sources                                 |                     |
-| `destination`          | Hash          | Default global syslog destinations| Syslog-NG server global log destinations                           |                     |
-| `filter`               | Hash          | Default global syslog filters    | Syslog-NG server global log filters                                 |                     |
-| `log`                  | Hash          | Default global syslog logs       | Syslog-NG server global logs                                        |                     |
-| `preinclude`           | Array         |                                  | Files to include at the beginning of the global configuration file  |                     |
-| `include`              | Array         |                                  | Files to include in the global configuration file                   |                     |
+| Name             | Type          | Default                            | Description                                                        | Allowed Values |
+| ---------------- | ------------- | ---------------------------------- | ------------------------------------------------------------------ | -------------- |
+| `config_file`    | String        | `/etc/syslog-ng/syslog-ng.conf`    | The path to the Syslog-NG server configuration on disk             |                |
+| `config_version` | String, Float | Installed version                  | The configuration file software version                            |                |
+| `cookbook`       | String        | `syslog-ng`                        | Cookbook to source configuration file template from                |                |
+| `template`       | String        | `syslog-ng/syslog-ng.conf.erb`     | Template to use to generate the configuration file                 |                |
+| `owner`          | String        | `root`                             | Owner of the generated configuration file                          |                |
+| `group`          | String        | `root`                             | Group of the generated configuration file                          |                |
+| `mode`           | String        | `0640`                             | Filemode of the generated configuration file                       |                |
+| `options`        | Hash          | Default global syslog options      | Syslog-NG server global options                                    |                |
+| `source`         | Hash          | Default global syslog sources      | Syslog-NG server global log sources                                |                |
+| `destination`    | Hash          | Default global syslog destinations | Syslog-NG server global log destinations                           |                |
+| `filter`         | Hash          | Default global syslog filters      | Syslog-NG server global log filters                                |                |
+| `log`            | Hash          | Default global syslog logs         | Syslog-NG server global logs                                       |                |
+| `preinclude`     | Array         |                                    | Files to include at the beginning of the global configuration file |                |
+| `include`        | Array         |                                    | Files to include in the global configuration file                  |                |
 
 ## Usage
 

--- a/documentation/syslog_ng_filter.md
+++ b/documentation/syslog_ng_filter.md
@@ -11,16 +11,16 @@
 
 ## Properties
 
-| Name                   | Type          | Default                          | Description                                                         | Allowed Values      |
-| ---------------------- | ------------- | -------------------------------- | ------------------------------------------------------------------- | ------------------- |
-| `config_dir`           | String        | `/etc/syslog-ng/filter.d`        | Directory to create configuration file in                           |                     |
-| `cookbook`             | String        | `syslog-ng`                      | Cookbook to source configuration file template from                 |                     |
-| `template`             | String        | `syslog-ng/filter.conf.erb`      | Template to use to generate the configuration file                  |                     |
-| `owner`                | String        | `root`                           | Owner of the generated configuration file                           |                     |
-| `group`                | String        | `root`                           | Group of the generated configuration file                           |                     |
-| `mode`                 | String        | `'0640'`                         | Filemode of the generated configuration file                        |                     |
-| `description`          | String        |                                  | Unparsed description to add to the configuration file               |                     |
-| `parameters`           | Hash, Array, String |                            | Filter(s) parameters and options                                    |                     |
+| Name          | Type                | Default                     | Description                                           | Allowed Values |
+| ------------- | ------------------- | --------------------------- | ----------------------------------------------------- | -------------- |
+| `config_dir`  | String              | `/etc/syslog-ng/filter.d`   | Directory to create configuration file in             |                |
+| `cookbook`    | String              | `syslog-ng`                 | Cookbook to source configuration file template from   |                |
+| `template`    | String              | `syslog-ng/filter.conf.erb` | Template to use to generate the configuration file    |                |
+| `owner`       | String              | `root`                      | Owner of the generated configuration file             |                |
+| `group`       | String              | `root`                      | Group of the generated configuration file             |                |
+| `mode`        | String              | `'0640'`                    | Filemode of the generated configuration file          |                |
+| `description` | String              |                             | Unparsed description to add to the configuration file |                |
+| `parameters`  | Hash, Array, String |                             | Filter(s) parameters and options                      |                |
 
 ## Usage
 

--- a/documentation/syslog_ng_log.md
+++ b/documentation/syslog_ng_log.md
@@ -11,22 +11,22 @@
 
 ## Properties
 
-| Name                   | Type          | Default                          | Description                                                         | Allowed Values      |
-| ---------------------- | ------------- | -------------------------------- | ------------------------------------------------------------------- | ------------------- |
-| `config_dir`           | String        | `/etc/syslog-ng/destionation.d`  | Directory to create configuration file in                           |                     |
-| `cookbook`             | String        | `syslog-ng`                      | Cookbook to source configuration file template from                 |                     |
-| `template`             | String        | `syslog-ng/destination.conf.erb` | Template to use to generate the configuration file                  |                     |
-| `owner`                | String        | `root`                           | Owner of the generated configuration file                           |                     |
-| `group`                | String        | `root`                           | Group of the generated configuration file                           |                     |
-| `mode`                 | String        | `'0640'`                         | Filemode of the generated configuration file                        |                     |
-| `description`          | String        |                                  | Unparsed description to add to the configuration file               |                     |
-| `source`               | String, Array, Hash |                            | Source(s) to collect logs from                                      |                     |
-| `filter`               | String, Array, Hash |                            | Filter(s) to apply to logs                                          |                     |
-| `destination`          | String, Array, Hash |                            | Destination(s) to output logs                                       |                     |
-| `flags`                | String, Array, Hash |                            | Flag(s) to apply                                                    |                     |
-| `parser`               | String, Array, Hash |                            | Parser(s) to apply                                                  |                     |
-| `rewrite`              | String, Array, Hash |                            | Rewrite(s) to apply                                                 |                     |
-| `junction`             | String, Array, Hash |                            | Junction(s) to split/combine logs                                   |                     |
+| Name          | Type                | Default                          | Description                                           | Allowed Values |
+| ------------- | ------------------- | -------------------------------- | ----------------------------------------------------- | -------------- |
+| `config_dir`  | String              | `/etc/syslog-ng/destionation.d`  | Directory to create configuration file in             |                |
+| `cookbook`    | String              | `syslog-ng`                      | Cookbook to source configuration file template from   |                |
+| `template`    | String              | `syslog-ng/destination.conf.erb` | Template to use to generate the configuration file    |                |
+| `owner`       | String              | `root`                           | Owner of the generated configuration file             |                |
+| `group`       | String              | `root`                           | Group of the generated configuration file             |                |
+| `mode`        | String              | `'0640'`                         | Filemode of the generated configuration file          |                |
+| `description` | String              |                                  | Unparsed description to add to the configuration file |                |
+| `source`      | String, Array, Hash |                                  | Source(s) to collect logs from                        |                |
+| `filter`      | String, Array, Hash |                                  | Filter(s) to apply to logs                            |                |
+| `destination` | String, Array, Hash |                                  | Destination(s) to output logs                         |                |
+| `flags`       | String, Array, Hash |                                  | Flag(s) to apply                                      |                |
+| `parser`      | String, Array, Hash |                                  | Parser(s) to apply                                    |                |
+| `rewrite`     | String, Array, Hash |                                  | Rewrite(s) to apply                                   |                |
+| `junction`    | String, Array, Hash |                                  | Junction(s) to split/combine logs                     |                |
 
 ## Usage
 

--- a/documentation/syslog_ng_service.md
+++ b/documentation/syslog_ng_service.md
@@ -13,12 +13,12 @@
 
 ## Properties
 
-| Name                   | Type          | Default                          | Description                                                         | Allowed Values      |
-| ---------------------- | ------------- | -------------------------------- | ------------------------------------------------------------------- | ------------------- |
-| `service_name`         | String        | `syslog-ng`                      | The service name to perform actions upon                            |                     |
-| `config_file`          | String        | `/etc/syslog-ng/syslog-ng.conf`  | The full path to the syslog-ng server configuration on disk         |                     |
-| `config_test`          | True, False   | `true`                           | Perform a configuration file test before performing service action  |                     |
-| `config_test_fail_action` | Symbol     | `:raise`                         | Action to perform upon a configuration test failure                 | `:raise`, `:log`    |
+| Name                      | Type        | Default                         | Description                                                        | Allowed Values   |
+| ------------------------- | ----------- | ------------------------------- | ------------------------------------------------------------------ | ---------------- |
+| `service_name`            | String      | `syslog-ng`                     | The service name to perform actions upon                           |                  |
+| `config_file`             | String      | `/etc/syslog-ng/syslog-ng.conf` | The full path to the syslog-ng server configuration on disk        |                  |
+| `config_test`             | True, False | `true`                          | Perform a configuration file test before performing service action |                  |
+| `config_test_fail_action` | Symbol      | `:raise`                        | Action to perform upon a configuration test failure                | `:raise`, `:log` |
 
 ### Example
 

--- a/libraries/_config.rb
+++ b/libraries/_config.rb
@@ -217,7 +217,7 @@ module SyslogNg
       end
 
       def message_append_caller(message)
-        "#{caller[1][/`.*'/][1..-2]}: #{message}"
+        "#{caller.find { |v| v.match?(/\.rb:\d+/) }[/[`'].*'/][1..-2]}: #{message}"
       end
     end
   end


### PR DESCRIPTION
# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
